### PR TITLE
Convert f32 to f128

### DIFF
--- a/convert_test.go
+++ b/convert_test.go
@@ -279,6 +279,76 @@ func BenchmarkFloat32_Float64(b *testing.B) {
 	}
 }
 
+func TestFloat64_Float128(t *testing.T) {
+	tests := []struct {
+		in   Float32
+		want Float128
+	}{
+		// https://en.wikipedia.org/wiki/Single-precision_floating-point_format
+		{
+			in:   0.0,
+			want: Float128{0x0000_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   Float32(math.Copysign(0, -1)), // -0
+			want: Float128{0x8000_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   1.0,
+			want: Float128{0x3fff_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   2.0,
+			want: Float128{0x4000_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   -2.0,
+			want: Float128{0xc000_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   0x1p-149, // smallest positive subnormal number
+			want: Float128{0x3f6a_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   0x1.fffffcp-127, // largest subnormal number
+			want: Float128{0x3f80_ffff_fc00_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   0x1p-126, // smallest positive normal number
+			want: Float128{0x3f81_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   0x1.fffffep+127, // largest normal number
+			want: Float128{0x407e_ffff_fe00_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   Float32(math.Inf(1)),
+			want: Float128{0x7fff_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   Float32(math.Inf(-1)),
+			want: Float128{0xffff_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   Float32(math.NaN()),
+			want: Float128{0x7fff_8000_0000_0000, 0x0000_0000_0000_0000},
+		},
+	}
+
+	for _, tt := range tests {
+		if got := tt.in.Float128(); got != tt.want {
+			t.Errorf("Float32(%x).Float64() = %x, want %x", tt.in, got, tt.want)
+		}
+	}
+}
+
+func BenchmarkFloat64_Float128(b *testing.B) {
+	f := Float64(1.0)
+	for b.Loop() {
+		runtime.KeepAlive(f.Float128())
+	}
+}
+
 func TestFloat64_Float32(t *testing.T) {
 	tests := []struct {
 		in   Float64

--- a/convert_test.go
+++ b/convert_test.go
@@ -337,7 +337,7 @@ func TestFloat64_Float128(t *testing.T) {
 
 	for _, tt := range tests {
 		if got := tt.in.Float128(); got != tt.want {
-			t.Errorf("Float32(%x).Float64() = %x, want %x", tt.in, got, tt.want)
+			t.Errorf("Float32(%x).Float128() = %x, want %x", tt.in, got, tt.want)
 		}
 	}
 }

--- a/convert_test.go
+++ b/convert_test.go
@@ -279,7 +279,7 @@ func BenchmarkFloat32_Float64(b *testing.B) {
 	}
 }
 
-func TestFloat64_Float128(t *testing.T) {
+func TestFloat32_Float128(t *testing.T) {
 	tests := []struct {
 		in   Float32
 		want Float128
@@ -342,8 +342,8 @@ func TestFloat64_Float128(t *testing.T) {
 	}
 }
 
-func BenchmarkFloat64_Float128(b *testing.B) {
-	f := Float64(1.0)
+func BenchmarkFloat32_Float128(b *testing.B) {
+	f := Float32(1.0)
 	for b.Loop() {
 		runtime.KeepAlive(f.Float128())
 	}

--- a/internal/cmd/float_test/main.go
+++ b/internal/cmd/float_test/main.go
@@ -49,6 +49,10 @@ func main() {
 		if err := f32_to_f64(); err != nil {
 			log.Fatal(err)
 		}
+	case "f32_to_f128":
+		if err := f32_to_f128(); err != nil {
+			log.Fatal(err)
+		}
 	case "f64_to_f32":
 		if err := f64_to_f32(); err != nil {
 			log.Fatal(err)
@@ -205,6 +209,37 @@ func f32_to_f64() error {
 			log.Printf("f32: %s, f64: %s", s32, s64)
 			log.Printf("got: %x, want: %x", got, f64)
 			return fmt.Errorf("f32(%x).Float64() = %x, want %x", f32, got, f64)
+		}
+		count.Add(1)
+	}
+	return nil
+}
+
+func f32_to_f128() error {
+	for {
+		var s32, s128, flag string
+		if _, err := fmt.Scanf("%s %s %s", &s32, &s128, &flag); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+
+		f32, err := parseFloat32(s32)
+		if err != nil {
+			return err
+		}
+
+		f128, err := parseFloat128(s128)
+		if err != nil {
+			return err
+		}
+
+		got := f32.Float128()
+		if !eq128(got, f128) {
+			log.Printf("f32: %s, f128: %s", s32, s128)
+			log.Printf("got: %x, want: %x", got, f128)
+			return fmt.Errorf("f32(%x).Float128() = %x, want %x", f32, got, f128)
 		}
 		count.Add(1)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for converting 32-bit floating point values to 128-bit floating point format.
- **Tests**
  - Introduced comprehensive tests and benchmarks for verifying and measuring the performance of 32-bit to 128-bit float conversions.
  - Enhanced command-line test tool with a new case for validating 32-bit to 128-bit float conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->