### PR TITLE
Implement Float128 conversion for Float64 and add corresponding tests

### DIFF
--- a/convert_test.go
+++ b/convert_test.go
@@ -645,3 +645,73 @@ func TestFloat64_Float64(t *testing.T) {
 		}
 	}
 }
+
+func TestFloat64_Float128(t *testing.T) {
+	tests := []struct {
+		in   Float64
+		want Float128
+	}{
+		// from https://en.wikipedia.org/wiki/Double-precision_floating-point_format
+		{
+			in:   0.0,
+			want: Float128{0x0000_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   Float64(math.Copysign(0, -1)), // -0
+			want: Float128{0x8000_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   1.0,
+			want: Float128{0x3fff_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   2.0,
+			want: Float128{0x4000_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   -2.0,
+			want: Float128{0xc000_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   0x1p-1074, // smallest positive subnormal number
+			want: Float128{0x3bcd_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   0x1.ffffffffffffep-1023, // largest subnormal number
+			want: Float128{0x3c00_ffff_ffff_ffff, 0xe000_0000_0000_0000},
+		},
+		{
+			in:   0x1p-1022, // smallest positive normal number
+			want: Float128{0x3c01_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   0x1.fffffffffffffp+1023, // largest normal number
+			want: Float128{0x43fe_ffff_ffff_ffff, 0xf000_0000_0000_0000},
+		},
+		{
+			in:   Float64(math.Inf(1)),
+			want: Float128{0x7fff_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   Float64(math.Inf(-1)),
+			want: Float128{0xffff_0000_0000_0000, 0x0000_0000_0000_0000},
+		},
+		{
+			in:   Float64(math.NaN()),
+			want: Float128{0x7fff_8000_0000_0000, 0x0000_0000_0000_0000},
+		},
+	}
+
+	for _, tt := range tests {
+		if got := tt.in.Float128(); !eq128(got, tt.want) {
+			t.Errorf("Float64(%x).Float128() = %x, want %x", tt.in, got, tt.want)
+		}
+	}
+}
+
+func BenchmarkTestFloat64_Float128(b *testing.B) {
+	f := Float64(1.0)
+	for b.Loop() {
+		runtime.KeepAlive(f.Float128())
+	}
+}

--- a/internal/cmd/float_test/main.go
+++ b/internal/cmd/float_test/main.go
@@ -60,6 +60,10 @@ func main() {
 		if err := f64_to_f32(); err != nil {
 			log.Fatal(err)
 		}
+	case "f64_to_f128":
+		if err := f64_to_f128(); err != nil {
+			log.Fatal(err)
+		}
 	}
 }
 
@@ -305,6 +309,37 @@ func f64_to_f32() error {
 			log.Printf("f64: %s, f32: %s", s64, s32)
 			log.Printf("got: %x, want: %x", got, f32)
 			return fmt.Errorf("f64(%x).Float32() = %x, want %x", f64, got, f32)
+		}
+		count.Add(1)
+	}
+	return nil
+}
+
+func f64_to_f128() error {
+	for {
+		var s64, s128, flag string
+		if _, err := fmt.Scanf("%s %s %s", &s64, &s128, &flag); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+
+		f64, err := parseFloat64(s64)
+		if err != nil {
+			return err
+		}
+
+		f128, err := parseFloat128(s128)
+		if err != nil {
+			return err
+		}
+
+		got := f64.Float128()
+		if !eq128(got, f128) {
+			log.Printf("f64: %s, f128: %s", s64, s128)
+			log.Printf("got: %x, want: %x", got, f128)
+			return fmt.Errorf("f64(%x).Float128() = %x, want %x", f64, got, f128)
 		}
 		count.Add(1)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for converting 64-bit floating-point numbers to 128-bit floating-point numbers, with correct handling of special cases such as zero, subnormal values, infinity, and NaN.

- **Tests**
  - Introduced comprehensive tests to verify the accuracy of 64-bit to 128-bit floating-point conversions, covering various edge cases.
  - Added benchmark tests to measure the performance of the conversion process.

- **Chores**
  - Enhanced the command-line test tool with a new case for validating 64-bit to 128-bit floating-point conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->