### PR TITLE
Fix Float128 to Float16 conversion rounding error and add test case f…

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -437,7 +437,7 @@ func (a Float128) Float32() Float32 {
 		roundBit := -exp + shift128 - (bias32 + shift32 - 1) - 64
 		halfMinusULP := uint64(1<<(roundBit-1) - 1)
 		frac[0] |= squash64(frac[1])
-		frac[0] += halfMinusULP + ((a[0] >> uint(roundBit)) & 1)
+		frac[0] += halfMinusULP + ((frac[0] >> uint(roundBit)) & 1)
 		return Float32(math.Float32frombits(sign | uint32(frac[0]>>uint(roundBit))))
 	}
 

--- a/convert.go
+++ b/convert.go
@@ -392,7 +392,7 @@ func (a Float128) Float16() Float16 {
 		roundBit := -exp + shift128 - (bias16 + shift16 - 1) - 64
 		halfMinusULP := uint64(1<<(roundBit-1) - 1)
 		frac[0] |= squash64(frac[1])
-		frac[0] += halfMinusULP + ((a[0] >> uint(roundBit)) & 1)
+		frac[0] += halfMinusULP + ((frac[0] >> uint(roundBit)) & 1)
 		return Float16(sign | uint16(frac[0]>>roundBit))
 	}
 

--- a/convert_test.go
+++ b/convert_test.go
@@ -883,6 +883,10 @@ func TestFloat128_Float16(t *testing.T) {
 			in:   Float128{0x3fe7_0000_0000_0000, 0x0000_0000_0000_0000}, // 0x1p-24
 			want: 0x0001,
 		},
+		{
+			in:   Float128{0x3fe6_0000_0000_0000, 0x0000_0000_0000_0000}, // 0x1p-25
+			want: 0x0000,
+		},
 
 		// test rounding to even
 		{

--- a/convert_test.go
+++ b/convert_test.go
@@ -883,10 +883,6 @@ func TestFloat128_Float16(t *testing.T) {
 			in:   Float128{0x3fe7_0000_0000_0000, 0x0000_0000_0000_0000}, // 0x1p-24
 			want: 0x0001,
 		},
-		{
-			in:   Float128{0x3fe6_0000_0000_0000, 0x0000_0000_0000_0000}, // 0x1p-25
-			want: 0x0000,
-		},
 
 		// test rounding to even
 		{
@@ -918,6 +914,12 @@ func TestFloat128_Float16(t *testing.T) {
 		{
 			in:   Float128{0x43fe_7fd1_da78_7c72, 0xdb6b_d758_0349_b96f},
 			want: 0x7c00,
+		},
+
+		// underflow
+		{
+			in:   Float128{0x3fe6_0000_0000_0000, 0x0000_0000_0000_0000}, // 0x1p-25
+			want: 0x0000,
 		},
 	}
 

--- a/convert_test.go
+++ b/convert_test.go
@@ -1006,6 +1006,12 @@ func TestFloat128_Float32(t *testing.T) {
 			in:   Float128{0x407e_ffff_ff00_0000, 0x0000_0000_0000_0000},
 			want: Float32(math.Inf(1)),
 		},
+
+		// underflow
+		{
+			in:   Float128{0x3f69_0000_0000_0000, 0x0000_0000_0000_0000}, // 0x1p-150
+			want: 0.0,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
…or edge value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected rounding logic for subnormal numbers during conversion from 128-bit to 16-bit and 32-bit floating-point formats, improving accuracy.

- **Tests**
  - Added test cases to validate conversion of specific subnormal values from 128-bit to 16-bit and 32-bit floats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->