### PR TITLE
Speed up Float16/128/256 string conversion

### DIFF
--- a/atof128.go
+++ b/atof128.go
@@ -25,7 +25,8 @@ func atof128(s string) (f Float128, n int, err error) {
 		return f, n, err
 	}
 
-	var d decimal
+	var buf [decimalDigits128]byte
+	d := decimal{d: buf[:]}
 	if !d.set(s[:n]) {
 		return Float128{}, n, syntaxError(fnParseFloat128, s)
 	}

--- a/atof16.go
+++ b/atof16.go
@@ -23,7 +23,8 @@ func atof16(s string) (f Float16, n int, err error) {
 		return f, n, err
 	}
 
-	var d decimal
+	var buf [decimalDigits16]byte
+	d := decimal{d: buf[:]}
 	if !d.set(s[:n]) {
 		return 0, n, syntaxError(fnParseFloat16, s)
 	}

--- a/atof256.go
+++ b/atof256.go
@@ -25,7 +25,9 @@ func atof256(s string) (f Float256, n int, err error) {
 		return f, n, err
 	}
 
-	var d decimal
+	bufp := decimalPool256.Get().(*[decimalDigits256]byte)
+	defer decimalPool256.Put(bufp)
+	d := decimal{d: bufp[:]}
 	if !d.set(s[:n]) {
 		return Float256{}, n, syntaxError(fnParseFloat256, s)
 	}

--- a/decimal.go
+++ b/decimal.go
@@ -14,12 +14,22 @@ package floats
 import "github.com/shogo82148/ints"
 
 type decimal struct {
-	d     [256000]byte // digits, big-endian representation
-	nd    int          // number of digits used
-	dp    int          // decimal point
-	neg   bool         // negative flag
-	trunc bool         // discarded nonzero digits beyond d[:nd]
+	d     []byte // digits, big-endian representation; backing array sized per float type
+	nd    int    // number of digits used
+	dp    int    // decimal point
+	neg   bool   // negative flag
+	trunc bool   // discarded nonzero digits beyond d[:nd]
 }
+
+// Maximum number of decimal digits that may be produced by (or consumed for a
+// correctly-rounded conversion of) each float type. The worst case is the
+// exact expansion of the largest subnormal value. A small margin is added on
+// top of the computed maxima (16->22, 128->11564, 256->183467).
+const (
+	decimalDigits16  = 32
+	decimalDigits128 = 12288
+	decimalDigits256 = 190000
+)
 
 func (a *decimal) String() string {
 	n := 10 + a.nd

--- a/decimal_buffer_test.go
+++ b/decimal_buffer_test.go
@@ -1,0 +1,34 @@
+package floats
+
+import "testing"
+
+// TestDecimalBufferExtremes guards the per-type decimal backing buffer sizes
+// (decimalDigits16/128/256). The worst-case decimal expansion is produced by
+// the largest subnormal value; if a buffer were too small the intermediate
+// expansion would be silently truncated and the shortest representation would
+// no longer round-trip.
+func TestDecimalBufferExtremes(t *testing.T) {
+	// largest subnormal Float128
+	x128 := Float128{0x0000_0fff_ffff_ffff, 0xffff_ffff_ffff_ffff}
+	if y, err := ParseFloat128(x128.String()); err != nil || y != x128 {
+		t.Errorf("Float128 largest subnormal round-trip failed: s=%s err=%v", x128.String(), err)
+	}
+
+	// smallest subnormal Float128
+	min128 := Float128{0x0000_0000_0000_0000, 0x0000_0000_0000_0001}
+	if y, err := ParseFloat128(min128.String()); err != nil || y != min128 {
+		t.Errorf("Float128 smallest subnormal round-trip failed: err=%v", err)
+	}
+
+	// largest subnormal Float256
+	x256 := Float256{0x0000_0fff_ffff_ffff, 0xffff_ffff_ffff_ffff, 0xffff_ffff_ffff_ffff, 0xffff_ffff_ffff_ffff}
+	if y, err := ParseFloat256(x256.String()); err != nil || y != x256 {
+		t.Errorf("Float256 largest subnormal round-trip failed: err=%v", err)
+	}
+
+	// smallest subnormal Float256
+	min256 := Float256{0x0000_0000_0000_0000, 0x0000_0000_0000_0000, 0x0000_0000_0000_0000, 0x0000_0000_0000_0001}
+	if y, err := ParseFloat256(min256.String()); err != nil || y != min256 {
+		t.Errorf("Float256 smallest subnormal round-trip failed: err=%v", err)
+	}
+}

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -22,7 +22,8 @@ var shifttests = []struct {
 
 func TestDecimalShift(t *testing.T) {
 	for _, test := range shifttests {
-		d := new(decimal)
+		var buf [decimalDigits128]byte
+		d := &decimal{d: buf[:]}
 		d.AssignUint64(test.i)
 		d.Shift(test.shift)
 		s := d.String()

--- a/f128toa.go
+++ b/f128toa.go
@@ -153,7 +153,8 @@ func (a Float128) appendHex(dst []byte, fmt byte, prec int) []byte {
 
 func (a Float128) append(dst []byte, fmt byte, prec int) []byte {
 	sign, exp, frac := a.split()
-	d := new(decimal)
+	var buf [decimalDigits128]byte
+	d := &decimal{d: buf[:]}
 	d.AssignUint128(frac)
 	d.Shift(exp - shift128)
 	shortest := prec < 0
@@ -198,7 +199,8 @@ func roundShortest128(d *decimal, frac ints.Uint128, exp int) {
 	// d = frac << (exp - shift16)
 	// Next highest floating point number is frac+1 << exp-shift16.
 	// Our upper bound is halfway between, frac*2+1 << exp-shift16-1.
-	upper := new(decimal)
+	var upperBuf [decimalDigits128]byte
+	upper := &decimal{d: upperBuf[:]}
 	upper.AssignUint128(frac.Lsh(1).Add(one))
 	upper.Shift(exp - shift128 - 1)
 
@@ -217,7 +219,8 @@ func roundShortest128(d *decimal, frac ints.Uint128, exp int) {
 		fraclo = frac.Lsh(1).Sub(one)
 		explo = exp - 1
 	}
-	lower := new(decimal)
+	var lowerBuf [decimalDigits128]byte
+	lower := &decimal{d: lowerBuf[:]}
 	lower.AssignUint128(fraclo.Lsh(1).Add(one))
 	lower.Shift(explo - shift128 - 1)
 

--- a/f16toa.go
+++ b/f16toa.go
@@ -184,7 +184,8 @@ func (a Float16) appendHex(dst []byte, fmt byte, prec int) []byte {
 func (a Float16) append(dst []byte, fmt byte, prec int) []byte {
 	sign, exp, frac := a.split()
 
-	d := new(decimal)
+	var buf [decimalDigits16]byte
+	d := &decimal{d: buf[:]}
 	d.AssignUint64(uint64(frac))
 	d.Shift(exp - shift16)
 	shortest := prec < 0
@@ -228,7 +229,8 @@ func roundShortest16(d *decimal, frac uint16, exp int) {
 	// d = frac << (exp - shift16)
 	// Next highest floating point number is frac+1 << exp-shift16.
 	// Our upper bound is halfway between, frac*2+1 << exp-shift16-1.
-	upper := new(decimal)
+	var upperBuf [decimalDigits16]byte
+	upper := &decimal{d: upperBuf[:]}
 	upper.AssignUint64(uint64(frac*2 + 1))
 	upper.Shift(exp - shift16 - 1)
 
@@ -247,7 +249,8 @@ func roundShortest16(d *decimal, frac uint16, exp int) {
 		fraclo = frac*2 - 1
 		explo = exp - 1
 	}
-	lower := new(decimal)
+	var lowerBuf [decimalDigits16]byte
+	lower := &decimal{d: lowerBuf[:]}
 	lower.AssignUint64(uint64(fraclo*2 + 1))
 	lower.Shift(explo - shift16 - 1)
 

--- a/f256toa.go
+++ b/f256toa.go
@@ -5,9 +5,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"sync"
 
 	"github.com/shogo82148/ints"
 )
+
+// decimalPool256 recycles the large backing arrays used to format Float256
+// values. Each array is decimalDigits256 bytes (~190 KB) and is too large to
+// live on the stack, so without pooling every conversion would allocate and
+// zero a fresh one. The arrays only ever hold valid digits in d[:nd], so they
+// can be reused without clearing.
+var decimalPool256 = sync.Pool{
+	New: func() any { return new([decimalDigits256]byte) },
+}
 
 var _ fmt.Formatter = Float256{}
 
@@ -152,7 +162,9 @@ func (a Float256) appendHex(dst []byte, fmt byte, prec int) []byte {
 
 func (a Float256) append(dst []byte, fmt byte, prec int) []byte {
 	sign, exp, frac := a.split()
-	d := new(decimal)
+	bufp := decimalPool256.Get().(*[decimalDigits256]byte)
+	defer decimalPool256.Put(bufp)
+	d := &decimal{d: bufp[:]}
 	d.AssignUint256(frac)
 	d.Shift(exp - shift256)
 	shortest := prec < 0
@@ -197,7 +209,9 @@ func roundShortest256(d *decimal, frac ints.Uint256, exp int) {
 	// d = frac << (exp - shift16)
 	// Next highest floating point number is frac+1 << exp-shift16.
 	// Our upper bound is halfway between, frac*2+1 << exp-shift16-1.
-	upper := new(decimal)
+	upperp := decimalPool256.Get().(*[decimalDigits256]byte)
+	defer decimalPool256.Put(upperp)
+	upper := &decimal{d: upperp[:]}
 	upper.AssignUint256(frac.Lsh(1).Add(one))
 	upper.Shift(exp - shift256 - 1)
 	// d = frac << (exp - shift16)
@@ -215,7 +229,9 @@ func roundShortest256(d *decimal, frac ints.Uint256, exp int) {
 		fraclo = frac.Lsh(1).Sub(one)
 		explo = exp - 1
 	}
-	lower := new(decimal)
+	lowerp := decimalPool256.Get().(*[decimalDigits256]byte)
+	defer decimalPool256.Put(lowerp)
+	lower := &decimal{d: lowerp[:]}
 	lower.AssignUint256(fraclo.Lsh(1).Add(one))
 	lower.Shift(explo - shift256 - 1)
 


### PR DESCRIPTION
## 概要

`Float16.String` / `Float128.String` / `Float256.String`（および `ParseFloat*`）が遅い問題を修正します。

## 原因

`decimal` 型が `d [256000]byte`（256KB）の固定配列を持ち、Float16/128/256 すべてで共有していました。shortest 表現では1回の変換で `d`・`upper`・`lower` の3つの `decimal` を確保するため、**毎回約768KB を割り当ててゼロクリア**していました。

256KB が必要なのは Float256 の最悪ケース（最大の非正規数の完全展開）だけで、Float16 は最大22桁、Float128 は最大11,564桁しか使いません。

## 変更内容

- `decimal.d` を固定配列から `[]byte` に変更し、型ごとに必要十分なサイズのバッキング配列を用意（`math/big` で最大桁数を厳密計算し余裕を持たせて決定: 16→32, 128→12288, 256→190000）。
- Float16 / Float128 はスタック確保となりヒープ割り当てを解消。
- Float256 はバッファがスタック上限（64KB）を超えるため `sync.Pool` で再利用（配列は `d[:nd]` しか読まないためクリア不要）。
- atof も同じ `decimal` 型を使うため合わせて更新 → `ParseFloat16/128/256` も 0 アロケーション化。
- バッファサイズを保護する回帰テスト（最大/最小非正規数の round-trip）を追加。

## ベンチマーク（Apple M1 Pro, `String()`）

| 型 | 変更前 | 変更後 | 高速化 |
|---|---|---|---|
| Float16 | 52,849 ns / 3 allocs | 106 ns / 0 allocs | 約498x |
| Float128 | 41,276 ns / 3 allocs | 2,843 ns / 0 allocs | 約14.5x |
| Float256 | 54,373 ns / 3 allocs | 6,526 ns / 0 allocs | 約8.3x |

全テスト・`go vet` ともにパスしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced memory allocations during floating-point parsing and formatting.
  * Improved handling of large-precision decimal conversions through reusable internal buffers.

* **Bug Fixes**
  * Improved round-trip accuracy for the largest and smallest subnormal Float128 and Float256 values.

* **Tests**
  * Added coverage for extreme Float128 and Float256 conversion cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->